### PR TITLE
Catch panics on corrupted load_from input and return ParseError

### DIFF
--- a/src/list/encoding/decode_oplog.rs
+++ b/src/list/encoding/decode_oplog.rs
@@ -445,15 +445,25 @@ impl Default for DecodeOptions {
 
 impl ListOpLog {
     pub fn load_from(data: &[u8]) -> Result<Self, ParseError> {
-        let mut oplog = Self::new();
-        oplog.decode_internal(data, DecodeOptions::default())?;
-        Ok(oplog)
+        Self::load_from_opts(data, DecodeOptions::default())
     }
 
     pub fn load_from_opts(data: &[u8], opts: DecodeOptions) -> Result<Self, ParseError> {
         let mut oplog = Self::new();
-        oplog.decode_internal(data, opts)?;
-        Ok(oplog)
+        // decode_internal assumes the encoded bytes are internally consistent, and some of the
+        // RLE / index lookups it does along the way panic instead of erroring out on corrupted
+        // input. Catch that here so a single flipped byte returns a ParseError like the docs
+        // promise, rather than taking down the caller.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            oplog.decode_internal(data, opts)
+        }));
+        match result {
+            Ok(res) => {
+                res?;
+                Ok(oplog)
+            }
+            Err(_) => Err(ParseError::GenericInvalidData),
+        }
     }
 
     /// Add all operations from a binary chunk into this document.

--- a/src/list/encoding/tests.rs
+++ b/src/list/encoding/tests.rs
@@ -388,3 +388,30 @@ fn compat_simple_doc() {
         assert_eq!(ListOpLog::load_from(bytes2_compressed_full).unwrap(), doc.oplog);
     }
 }
+
+#[test]
+fn corrupted_bytes_return_parse_error_instead_of_panicking() {
+    // load_from is documented to return a Result, but some corrupted inputs used to trip an
+    // internal unwrap() deep in the RLE decoding instead of surfacing a ParseError.
+    let doc = simple_doc();
+    let good_bytes = doc.oplog.encode(&EncodeOptions::full().store_deleted_content(true));
+
+    let mut found_an_error_case = false;
+    for i in 0..good_bytes.len() {
+        for &b in &[0u8, 2, 0xff] {
+            let mut corrupted = good_bytes.clone();
+            corrupted.splice(i..i, [b]);
+
+            let result = std::panic::catch_unwind(|| ListOpLog::load_from(&corrupted));
+            assert!(result.is_ok(), "load_from panicked on corrupted bytes at position {i} with inserted byte {b}");
+
+            if let Ok(Err(_)) = result {
+                found_an_error_case = true;
+            }
+        }
+    }
+
+    // Sanity check that this actually exercises some malformed input (rather than every
+    // mutation happening to still decode successfully).
+    assert!(found_an_error_case);
+}


### PR DESCRIPTION
Fixes #50.

`load_from` is documented to return a `Result`, but a single corrupted/flipped byte can make the RLE decoding path hit an internal `unwrap()`/index panic instead of returning a `ParseError`. Wrapped the decode call in `catch_unwind` so malformed input always comes back as `Err(ParseError::GenericInvalidData)`.

Added a test that fuzzes single-byte insertions into a valid encoded doc and checks `load_from` never panics (it fails without the fix at the same spot as the issue's repro).
